### PR TITLE
fix vocabulary generation

### DIFF
--- a/src/collective/contentsync/sync/vocabularies.py
+++ b/src/collective/contentsync/sync/vocabularies.py
@@ -42,7 +42,8 @@ class SyncTargetsVocabulary(object):
 
         for option in options or ():
             try:
-                target_id, title, _, _, _ = option.split("|")
+                target_id = option.get('id', '')
+                title = option.get('title', '')
             except ValueError:
                 continue
             items.append(SimpleTerm(value=target_id, title=title))


### PR DESCRIPTION
We are evaluating the add-on to use it in a client's site, and found this error.

After enabling the behavior in a content-type the edit form is unusable because when creating the vocabulary the id and title of the vocabulary terms are created splitting the content of the registry (expecting it to be a string), instead of getting the values from the obtained dict.

The traceback is the following one:

```
2021-09-09 11:25:30,452 ERROR   [Zope.SiteErrorLog:252][waitress] 1631179530.4519740.7321725534319327 http://localhost:5454/Plone/es-es/@@edit
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 371, in publish_module
  Module ZPublisher.WSGIPublisher, line 274, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.edit, line 58, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 141, in update
  Module z3c.form.group, line 52, in update
  Module z3c.form.group, line 48, in updateWidgets
  Module z3c.form.field, line 277, in update
  Module z3c.form.browser.multi, line 63, in update
  Module z3c.form.browser.widget, line 171, in update
  Module z3c.form.widget, line 496, in update
  Module Products.CMFPlone.patches.z3c_form, line 47, in _wrapped
  Module z3c.form.widget, line 132, in update
  Module z3c.form.widget, line 491, in value
  Module collective.z3cform.datagridfield.datagridfield, line 177, in updateWidgets
  Module collective.z3cform.datagridfield.datagridfield, line 149, in getWidget
  Module z3c.form.browser.widget, line 171, in update
  Module z3c.form.object, line 217, in update
  Module collective.z3cform.datagridfield.datagridfield, line 311, in updateWidgets
  Module z3c.form.object, line 208, in updateWidgets
  Module collective.z3cform.datagridfield.datagridfield, line 439, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 132, in update
  Module collective.z3cform.datagridfield.datagridfield, line 446, in updateWidgets
  Module z3c.form.form, line 136, in updateWidgets
  Module z3c.form.field, line 277, in update
  Module z3c.form.browser.select, line 51, in update
  Module z3c.form.browser.widget, line 171, in update
  Module z3c.form.widget, line 233, in update
  Module z3c.form.widget, line 227, in updateTerms
  Module zope.component._api, line 102, in getMultiAdapter
  Module zope.component._api, line 116, in queryMultiAdapter
  Module zope.interface.registry, line 365, in queryMultiAdapter
  Module zope.interface.adapter, line 564, in queryMultiAdapter
  Module z3c.form.term, line 105, in ChoiceTerms
  Module zope.schema._field, line 466, in bind
  Module zope.schema._field, line 450, in _resolve_vocabulary
  Module Zope2.App.schema, line 32, in get
  Module collective.contentsync.sync.vocabularies, line 45, in __call__
AttributeError: 'dict' object has no attribute 'split'
```