### PR TITLE
use an emtpy list if None is returned

### DIFF
--- a/src/collective/contentsync/sync/sync.py
+++ b/src/collective/contentsync/sync/sync.py
@@ -92,7 +92,7 @@ def _prepare_data(data, context=None, full=True):
         omitted_keys.extend(
             plone.api.portal.get_registry_record(
                 name="collective.contentsync.omitted_update_fields",
-                default=[]))
+                default=[]) or [])
     for key, value in copy.deepcopy(data).items():
         if key in omitted_keys:
             del data[key]


### PR DESCRIPTION
When no information has been saved in the registry, the value of this key is `None` and the `get_registry_record` methods returns it instead of `[]` and this makes the extend method to fail:

